### PR TITLE
chore: add /tasks/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /bin/
 /out/
 /target/
+/tasks/
 .metadata/
 # Archivos de IDE
 .idea/


### PR DESCRIPTION
The /tasks/ directory is now excluded from version control to prevent unnecessary files from being tracked